### PR TITLE
Adding support for access and refresh tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ install:
 
 script:
   - npm test
+
+services:
+  - redis-server

--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,7 @@
+const TOKEN_TYPE_ACCESS = 1;
+const TOKEN_TYPE_REFRESH = 2;
+
+module.exports = {
+  TOKEN_TYPE_ACCESS,
+  TOKEN_TYPE_REFRESH
+};

--- a/consts.js
+++ b/consts.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const TOKEN_TYPE_ACCESS = 1;
 const TOKEN_TYPE_REFRESH = 2;
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class JWTToken {
       tokenExpirationInSeconds: 3600,
       refreshTokenExpirationInSeconds: 3600
     };
+    this.tokenStorageManager = null;
   }
 
   /**
@@ -77,6 +78,10 @@ class JWTToken {
   */
   getPublicCert() {
     return this.publicCert;
+  }
+
+  setTokenStorageManager(manager) {
+    this.tokenStorageManager = manager;
   }
 
   /**
@@ -180,9 +185,7 @@ class JWTToken {
    */
   checkIfRefreshTokenUsed(token) {
     let hash = this.getTokenHash(token);
-    return new Promise((resolve, reject) => {
-      resolve(hash);
-    });
+    return this.tokenStorageManager ? this.tokenStorageManager.isTokenUsed(hash) : Promise.resolve(hash);
   }
 
   /**
@@ -191,9 +194,7 @@ class JWTToken {
    * @returns {Promise} Promise resolved when token has been marked as used
    */
   markRefreshTokenUsed(hash) {
-    return new Promise((resolve, reject) => {
-      resolve();
-    });
+    return this.tokenStorageManager ? this.tokenStorageManager.markTokenUsed(hash) : Promise.resolve();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "carlos.justiniano@gmail.com"
   },
   "scripts": {
-    "test": "mocha specs --reporter spec || true"
+    "test": "mocha specs --reporter spec"
   },
   "engines": {
     "node": ">=6.2.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "carlos.justiniano@gmail.com"
   },
   "scripts": {
-    "test": "mocha specs --reporter spec"
+    "test": "mocha specs"
   },
   "engines": {
     "node": ">=6.2.1"
@@ -24,6 +24,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "chai-as-promised": "^6.0.0",
+    "fwsp-cacher": "^1.0.2",
     "jsonwebtoken": "7.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/flywheelsports/fwsp-jwt-auth#readme",
   "dependencies": {
     "bluebird": "3.4.6",
+    "chai-as-promised": "^6.0.0",
     "jsonwebtoken": "7.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-jwt-auth",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "JSON Web Token Authentication Helper",
   "author": {
     "name": "Carlos Justiniano",

--- a/specs/helpers/chai.js
+++ b/specs/helpers/chai.js
@@ -1,8 +1,10 @@
 'use strict';
 
 var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
 
 chai.config.includeStack = true;
+chai.use(chaiAsPromised);
 
 global.expect = chai.expect;
 global.AssertionError = chai.AssertionError;

--- a/specs/test.js
+++ b/specs/test.js
@@ -12,19 +12,37 @@ jwtAuth.init({
   tokenExpirationInSeconds: 10
 });
 
+const {
+  TOKEN_TYPE_ACCESS, TOKEN_TYPE_REFRESH
+} = require('../consts');
+
 const payload = {
   userID: 34,
   admin: true
 };
 
+const wait = ms => {
+  return () => {
+    return new Promise(resolve => {
+      setTimeout(resolve, ms);
+    });
+  };
+}
+
+const now = () => {
+  return Math.floor(Date.now() / 1000);
+}
+
 describe('jwt-auth', () => {
   it('should be able to change default options', () => {
     jwtAuth.init({
-      tokenExpirationInSeconds: 100
+      tokenExpirationInSeconds: 100,
+      refreshTokenExpirationInSeconds: 100
     });
     let options = jwtAuth.getOptions();
     expect(options).to.be.an('object');
     expect(options.tokenExpirationInSeconds).to.equal(100);
+    expect(options.refreshTokenExpirationInSeconds).to.equal(100);
   });
 
   it('should fail to load misnamed cert', (done) => {
@@ -142,52 +160,76 @@ describe('jwt-auth', () => {
       });
   });
 
-  it('should be able to obtain a new token given a valid token', (done) => {
+
+  it('should be able to create an access token', () => {
+    const ACCESS_EXP = 100;
     jwtAuth.init({
-      tokenExpirationInSeconds: 5
+      tokenExpirationInSeconds: ACCESS_EXP,
+      refreshTokenExpirationInSeconds: 1000
     });
-    jwtAuth.loadCerts('./server.pem', './server.pub')
-      .then((result) => {
-        jwtAuth.createToken(payload)
-          .then((token) => {
-            jwtAuth.verifyToken(token)
-              .then((result) => {
-                // delay refresh token because a token refreshed within the same
-                // time second will return the same token value.
-                setTimeout(() => {
-                  jwtAuth.refreshToken(token)
-                    .then((newToken) => {
-                      expect(newToken).to.be.a('string');
-                      expect(newToken).to.not.equal(token);
-                      done();
-                    });
-                }, 1500);
-              });
-          });
+    return jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createAccessToken(payload))
+      .then(token => jwtAuth.verifyToken(token))
+      .then(res => {
+        expect(res.token_type).to.equal(TOKEN_TYPE_ACCESS);
+        expect(res.exp - now()).to.be.closeTo(ACCESS_EXP, 2);
       });
   });
 
-  it('should fail to obtain a new token given an invalid token', (done) => {
+  it('should be able to create a refresh token', () => {
+    const REFRESH_EXP = 100;
     jwtAuth.init({
-      tokenExpirationInSeconds: 1
+      tokenExpirationInSeconds: 1000,
+      refreshTokenExpirationInSeconds: REFRESH_EXP
     });
-    jwtAuth.loadCerts('./server.pem', './server.pub')
-      .then((result) => {
-        jwtAuth.createToken(payload)
-          .then((token) => {
-            jwtAuth.verifyToken(token)
-              .then((result) => {
-                // delay refresh token so that original token ends up expiring.
-                setTimeout(() => {
-                  jwtAuth.refreshToken(token)
-                  .catch((err) => {
-                    expect(err.message.indexOf('jwt expired')).to.be.above(-1);
-                    done();
-                  });
-                }, 1500);
-              });
-          });
+    return jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .then(token => jwtAuth.verifyToken(token))
+      .then(res => {
+        expect(res.token_type).to.equal(TOKEN_TYPE_REFRESH);
+        expect(res.exp - now()).to.be.closeTo(REFRESH_EXP, 2);
       });
+  });
+
+  it('should be able to execute a refresh of an unused refresh token', () => {
+    jwtAuth.init({});
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .then(token => jwtAuth.executeRefreshToken(token))
+      .then(data => expect(data).to.contain.all.keys(payload))
+
+    return expect(p).to.be.fulfilled;
+  });
+
+  it('should fail to execute a refresh of an access token', () => {
+    jwtAuth.init({});
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createAccessToken(payload))
+      .then(token => jwtAuth.executeRefreshToken(token));
+
+    return expect(p).to.be.rejected;
+  });
+
+  it('should fail to execute a refresh of a used refresh token', () => {
+    jwtAuth.init({});
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .then(token => jwtAuth.executeRefreshToken(token));
+
+    return expect(p).to.be.rejected;
+  });
+
+  it('should fail to execute a refresh of an expired refresh token', () => {
+    jwtAuth.init({
+      refreshTokenExpirationInSeconds: 1
+    });
+
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .tap(wait(1000))
+      .then(token => jwtAuth.executeRefreshToken(token));
+
+    return expect(p).to.be.rejected;
   });
 
   it('should return a token hash given a token', (done) => {
@@ -204,5 +246,30 @@ describe('jwt-auth', () => {
             done();
           });
       });
+  });
+
+  it('should be able to check if an unused refresh token has been used', () => {
+    jwtAuth.init({});
+
+    let hash;
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .tap(token => {
+        hash = jwtAuth.getTokenHash(token);
+      })
+      .then(token => jwtAuth.checkIfRefreshTokenUsed(token))
+      .tap(_hash => expect(_hash).to.equal(hash));
+
+    return expect(p).to.be.fulfilled;
+  });
+
+  it('should be able to check if a used refresh token has been used', () => {
+    jwtAuth.init({});
+
+    let p = jwtAuth.loadCerts('./server.pem', './server.pub')
+      .then(() => jwtAuth.createRefreshToken(payload))
+      .then(token => jwtAuth.checkIfRefreshTokenUsed(token));
+
+    return expect(p).to.be.rejected;
   });
 });

--- a/specs/token-storage-test.js
+++ b/specs/token-storage-test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+require('./helpers/chai.js');
+
+const {
+  MemoryTokenStorageManager,
+  RedisTokenStorageManager
+} = require('../token-storage');
+
+let tokenHash = 'abc';
+
+describe('MemoryTokenStorageManager', () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new MemoryTokenStorageManager();
+  });
+
+  it('should be able to tell that an unused token is unused', () => {
+    let p = manager.isTokenUsed(tokenHash);
+
+    return expect(p).to.eventually.equal(tokenHash);
+  });
+
+  it('should be able to mark an unused token as used', () => {
+    let p = manager.markTokenUsed(tokenHash);
+
+    return expect(p).to.be.fulfilled;
+  });
+
+  it('should be able to tell that a used token is used', () => {
+    let p = manager.markTokenUsed(tokenHash)
+      .then(() => manager.isTokenUsed(tokenHash));
+
+    return expect(p).to.be.rejected;
+  });
+
+  it('should fail to mark a used token as used', () => {
+    let p = manager.markTokenUsed(tokenHash)
+      .then(() => manager.markTokenUsed(tokenHash));
+
+    return expect(p).to.be.rejected;
+  });
+});
+
+describe('RedisTokenStorageManager', () => {
+  let manager;
+
+  beforeEach(() => {
+    let config = {
+      url: 'localhost',
+      port: 6379,
+      db: 15,
+      cachePrefix: `fwsp-jwt-auth-token-test-${Date.now()}`
+    };
+    manager = new RedisTokenStorageManager(config);
+  });
+
+  it('should be able to tell that an unused token is unused', () => {
+    let p = manager.isTokenUsed(tokenHash);
+
+    return expect(p).to.eventually.equal(tokenHash);
+  });
+
+  it('should be able to mark an unused token as used', () => {
+    let p = manager.markTokenUsed(tokenHash);
+
+    return expect(p).to.be.fulfilled;
+  });
+
+  it('should be able to tell that a used token is used', () => {
+    let p = manager.markTokenUsed(tokenHash)
+      .then(() => manager.isTokenUsed(tokenHash));
+
+    return expect(p).to.be.rejected;
+  });
+
+  it('should fail to mark a used token as used', () => {
+    let p = manager.markTokenUsed(tokenHash)
+      .then(() => manager.markTokenUsed(tokenHash));
+
+    return expect(p).to.be.rejected;
+  });
+});

--- a/token-storage.js
+++ b/token-storage.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Promise = require('bluebird');
+const Cacher = require('fwsp-cacher');
+
+class MemoryTokenStorageManager {
+  constructor() {
+    this.usedTokens = [];
+  }
+
+  isTokenUsed(hash) {
+    return Promise.resolve(hash)
+      .tap(hash => {
+        if (this.usedTokens.includes(hash)) {
+          throw new Error('Token Already Used');
+        }
+      });
+  }
+
+  markTokenUsed(hash) {
+    return this.isTokenUsed(hash)
+      .then(hash => {
+        this.usedTokens.push(hash);
+      });
+  }
+}
+
+class RedisTokenStorageManager {
+  constructor(config) {
+    this.cacher = new Cacher();
+    this.cacher.init(config);
+    this.cacher.setCachePrefix(config.cachePrefix || 'fwsp-jwt-auth-token');
+  }
+
+  isTokenUsed(hash) {
+    return this.cacher.getData(hash)
+      .then(data => {
+        if (data === hash) {
+          throw new Error('Token Already Used');
+        }
+        return hash;
+      });
+  }
+
+  markTokenUsed(hash) {
+    return this.isTokenUsed(hash)
+      .then(hash => this.cacher.setData(hash, hash, 63072000));
+  }
+}
+
+module.exports = {
+  MemoryTokenStorageManager,
+  RedisTokenStorageManager
+};


### PR DESCRIPTION
- Updated `createToken` to take a token type const
- Added helper functions `createAccessToken` and `createRefreshToken`
- Changed `refreshToken` to `executeRefreshToken`, which just validates the token, makes sure it's the right type of token, and that the token hasn't been used before
- ~~There are two new tests that are failing because the functionality to mark refresh tokens as used hasn't been implemented yet~~